### PR TITLE
Pipe `git rev-list` to `git cherry-pick`

### DIFF
--- a/gh-combine-dependabot-prs
+++ b/gh-combine-dependabot-prs
@@ -22,9 +22,7 @@ git checkout -b "$branch_name" origin/main
 
 for pr_number in "$@"; do
   head_sha=$(pr_sha $pr_number)
-  shas=$(git log "origin/main..${head_sha}" --format=format:%H --reverse)
-
-  git cherry-pick "$shas"
+  git rev-list --reverse "origin/main..${head_sha}" | git cherry-pick --stdin 
 done
 
 git push origin "$branch_name" --set-upstream


### PR DESCRIPTION
Thanks so much for creating this extension, @rosston @kmcq!

I tried running this to combine a dozen or so Dependabot PRs, but got this error:

```
fatal: bad revision 'e3b3bfea07698a6b984cbdbc10f785a9c2d443d5
```

That commit existed, and I could run `git cherry-pick e3b3bfea07698a6b984cbdbc10f785a9c2d443d5` without a problem. But for whatever reason, it wasn't getting applied correctly.

After some trial and error, I found that piping `git rev-list` to `git cherry-pick --stdin` worked as expected.